### PR TITLE
Update mqtt_server.c

### DIFF
--- a/main/mqtt_server.c
+++ b/main/mqtt_server.c
@@ -185,7 +185,19 @@ static void fn(struct mg_connection *c, int ev, void *ev_data, void *fn_data) {
 		int willFlag = _mg_mqtt_parse_header(mm, &cid, &topic, &payload, &qos, &retain);
 		ESP_LOGI(pcTaskGetName(NULL), "cid=[%.*s] willFlag=%d", cid.len, cid.ptr, willFlag);
 
-#if 0
+#if( 1)
+// new - find out if a connection with same client name already exists - if so shut it down (ChrisHul@github.com)
+
+		for (struct client *next, *client = s_clients; client != NULL; client = next) {
+			next = client->next;
+			if( cid.len == client->cid.len &&
+				 memcmp( cid.ptr, client->cid.ptr, cid.len) == 0)
+			{
+					client->c->is_closing = 1;
+			}
+		}
+// end of new section
+
 		// Client connects. Add to the client-id list
 		struct client *client = calloc(1, sizeof(*client));
 		client->c = c;


### PR DESCRIPTION
Socket connections seem to be sticky and peer abortion is not detected by the server.

Ran into problems with following configuration: #1. ESP32 with server, publisher and subscriber. #2. ESP32 with publisher and subscriber. #3 Generic MQTT client on android device subscribing and publishing. 

Number of allowed sockets is limited which creates problem in #1. Socket connections do not close on sudden abortion of #2 (reset/out of range). When #2 tries to connect again it obtains a new connection without previous connection being deleted. Result: socket handler gets saturated and returns error. Socket number is limited to 16 and I find no way around that.

Proposed fix: revival of clientid registration code (muted) in mqtt_server.c. On new connection: check if there is a working connection with the same clientid and force that one to close  if so.

This fix has been tested and working.